### PR TITLE
- added tickArray feature to allow arbitrary placement of ticks

### DIFF
--- a/tests/visual/labeledslider/variable_labels.html
+++ b/tests/visual/labeledslider/variable_labels.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html>
+<head>
+   <meta charset="utf-8">
+   <link rel="stylesheet" type="text/css" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css">
+
+   <title>LabeledSlider Variable Labels Test</title>
+
+   <script src="http://code.jquery.com/jquery.js"></script>
+   <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+
+   <link rel="stylesheet" href="../../../themes/base/jquery.ui.labeledslider.css">
+
+   <script src="../../../ui/jquery.ui.labeledslider.js"></script>
+
+   <script>
+   $(function() {
+      $('#slider1').labeledslider({ 
+        min: 4, 
+        max: 40,
+        tickArray: [4, 8, 12, 27, 33, 38, 40],
+        tickLabels: {
+          12:'cat',
+          38:'dog',
+        }
+      });
+   });
+   </script>
+   <style>
+
+   * {
+      font-family:   Verdana, Arial, Helvetica, sans-serif;
+      font-size:     12pt;
+   }
+
+   .wrapper {
+      position: relative;
+      margin: auto;
+      width: 400px;
+      height: 400px;
+      margin-top: 50px;
+   }
+
+   .controls {
+      position: absolute;
+      bottom: 30px;
+      right: 0;
+      font-size: 8pt;
+      text-align: right;
+   }
+   .controls .label { font-size: .9em; }
+   .ui-spinner { width: 4em; }
+
+   </style>
+</head>
+<body>
+
+<a href="https://github.com/bseth99/jquery-ui-extensions"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
+
+<div class="wrapper">
+   <h3>LabeledSlider Variable Labels Test</h3>
+   <div>
+      <a href="../index.html">&lt; Back to widget demos</a>
+   </div>
+   <br/>
+
+   <p>
+    For arbitrary placement of labels, instead of using the "tickInterval"
+    option, provide an array of tick positions to "tickArray".  Only those
+    items in the array will be displayed.  The option also works with the
+    "tickLabels" feature.  The slider below has the following setup:
+
+    <pre>
+      $('#slider1').labeledslider({ 
+        min: 4, 
+        max: 40,
+        tickArray: [4, 8, 12, 27, 33, 38, 40],
+        tickLabels: {
+          12:'cat',
+          38:'dog',
+        }
+      });
+    </pre>
+   </p>
+
+   <div id="slider1"></div>
+   <br/>
+</div>
+
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-34780028-1']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>
+</body>
+</html>

--- a/ui/jquery.ui.labeledslider.js
+++ b/ui/jquery.ui.labeledslider.js
@@ -40,7 +40,8 @@
       options: {
          tickInterval: 0,
          tweenLabels: true,
-         tickLabels: null
+         tickLabels: null,
+         tickArray: []
       },
 
       uiSlider: null,
@@ -85,17 +86,31 @@
              max = this.options.max,
              inr = this.tickInterval,
              cnt = ( max - min ) / inr,
+             tickArray = this.options.tickArray,
              i = 0;
 
          $lbl.html('');
 
-         for (;i<=cnt;i++) {
-            $('<div>').addClass( 'ui-slider-label-ticks' )
-               .css( dir, (Math.round( i / cnt * 10000 ) / 100) + '%' )
-               .html( '<span>'+( labels[i*inr+min] ? labels[i*inr+min] : (this.options.tweenLabels ? i*inr+min : '') )+'</span>' )
-               .appendTo( $lbl );
-         }
+         if( tickArray.length > 0 ) {
+            // tickArray provided, print labels only in the array
+            for( i=0; i<tickArray.length; i++ ) {
+                var label = labels[tickArray[i]];
+                label = label ? label : tickArray[i];
 
+                $('<div>').addClass( 'ui-slider-label-ticks' )
+                   .css( dir, (Math.round( (tickArray[i] - min)/ cnt * 10000 ) / 100) + '%' )
+                   .html( '<span>'+ label +'</span>' )
+                   .appendTo( $lbl );
+            }
+         }
+         else {
+             for (;i<=cnt;i++) {
+                $('<div>').addClass( 'ui-slider-label-ticks' )
+                   .css( dir, (Math.round( i / cnt * 10000 ) / 100) + '%' )
+                   .html( '<span>'+( labels[i*inr+min] ? labels[i*inr+min] : (this.options.tweenLabels ? i*inr+min : '') )+'</span>' )
+                   .appendTo( $lbl );
+             }
+         }
       },
 
       _setOption: function( key, value ) {
@@ -106,6 +121,7 @@
 
              case 'tickInterval':
              case 'tickLabels':
+             case 'tickArray':
              case 'min':
              case 'max':
              case 'step':


### PR DESCRIPTION
I needed the ability to have the ticks be in arbitrary spots, not just increments.  I've added "tickArray" as an option.  If given it ignores "tickInterval" and displays only those ticks given.  "tickArray" should be an array of tick positions.  The label drawing still respects the "tickLabels" feature but ignores the tween option.

I haven't regenerated any of the dist files to go with this, so this commit only updates the labelled slider file and adds a test html page.

Cool widget.  Thanks for putting it out there.
