### PR TITLE
Change to allow the slider width to be constrained by the parent element...

### DIFF
--- a/ui/jquery.ui.labeledslider.js
+++ b/ui/jquery.ui.labeledslider.js
@@ -66,10 +66,7 @@
 
          this._alignWithStep();
 
-         if ( this.orientation == 'horizontal' ) {
-            this.uiSlider
-               .width( this.element.width() );
-         } else {
+         if ( this.orientation != 'horizontal' ) {
             this.uiSlider
                .height( this.element.height() );
          }


### PR DESCRIPTION
....

With the previous code, the horizontal sliders were sized incorrectly when initialised in a hidden div. I can't see any reason to need to given an explicit width to the horizontal sliders, as they seem to work fine when constrained by the parent element.
