### PR TITLE
Fix for width bug.

### DIFF
--- a/ui/jquery.ui.labeledslider.js
+++ b/ui/jquery.ui.labeledslider.js
@@ -68,7 +68,7 @@
 
          if ( this.orientation == 'horizontal' ) {
             this.uiSlider
-               .width( this.element.width() );
+               .width( this.element.css('width') );
          } else {
             this.uiSlider
                .height( this.element.height() );

--- a/ui/jquery.ui.labeledslider.js
+++ b/ui/jquery.ui.labeledslider.js
@@ -71,7 +71,7 @@
                .width( this.element.css('width') );
          } else {
             this.uiSlider
-               .height( this.element.height() );
+               .height( this.element.css('height') );
          }
 
          this._drawLabels();


### PR DESCRIPTION
When using this.element.width(), you get an integer stripped of it's qualifier (px, %, em). This works fine when all elements are shown, though I'm not positive why (maybe CSS computes and returns a pixel width when it knows one?), but if you pass it 100% and then set the width, it gets understood as '100px' instead of '100%'. Switching over to this.element.css('width') returns the fully qualified width and sets properly even when an item is hidden and only known as 100% of something.
