### PR TITLE
Add "autofillsinglematch" option to combobox:

### DIFF
--- a/ui/jquery.ui.combobox.js
+++ b/ui/jquery.ui.combobox.js
@@ -130,36 +130,65 @@
          "autocompletechange input" : function(event, ui) {
 
             var $el = $(event.currentTarget);
-
+            var changedOption = ui.item ? ui.item.option : null;
             if ( !ui.item ) {
 
                var matcher = new RegExp( "^" + $.ui.autocomplete.escapeRegex( $el.val() ) + "$", "i" ),
-               valid = false;
+               valid = false,
+               matchContains = null,
+               iContains = 0,
+               iSelectCtr = -1,
+               iSelected = -1,
+               optContains = null;
+               if (this.options.autofillsinglematch) {
+                  matchContains = new RegExp($.ui.autocomplete.escapeRegex($el.val()), "i");
+               }
+
 
                this.element.children( "option" ).each(function() {
-                     if ( $( this ).text().match( matcher ) ) {
+                     var t = $(this).text();
+                     if ( t.match( matcher ) ) {
                         this.selected = valid = true;
                         return false;
+                     }
+                     if (matchContains) {
+                        // look for items containing the value
+                        iSelectCtr++;
+                        if (t.match(matchContains)) {
+                           iContains++;
+                           optContains = $(this);
+                           iSelected = iSelectCtr;
+                        }
                      }
                   });
 
                 if ( !valid ) {
+                   // autofill option:  if there is just one match, then select the matched option
+                   if (iContains == 1) {
+                      changedOption = optContains[0];
+                      changedOption.selected = true;
+                      var t2 = optContains.text();
+                      $el.val(t2);
+                      $el.data('ui-autocomplete').term = t2;
+                      this.element.prop('selectedIndex', iSelected);
+                      console.log("Found single match with '" + t2 + "'");
+                   } else {
 
-                   // remove invalid value, as it didn't match anything
-                   $el.val( '' );
+                      // remove invalid value, as it didn't match anything
+                      $el.val( '' );
 
-                   // Internally, term must change before another search is performed
-                   // if the same search is performed again, the menu won't be shown
-                   // because the value didn't actually change via a keyboard event
-                   $el.data( 'ui-autocomplete' ).term = '';
+                      // Internally, term must change before another search is performed
+                      // if the same search is performed again, the menu won't be shown
+                      // because the value didn't actually change via a keyboard event
+                      $el.data( 'ui-autocomplete' ).term = '';
 
-                   this.element.prop('selectedIndex', -1);
-
+                      this.element.prop('selectedIndex', -1);
+                   }
                 }
             }
 
             this._trigger( "change", event, {
-                  item: ui.item ? ui.item.option : null
+                  item: changedOption
                 });
 
          },


### PR DESCRIPTION
if there is a single matching option, accept it even if user has not typed in the full text.
Usage: $("select").combobox({ autofillsinglematch:1 })
Example:  For the <select> element below, if the user types "bama", only "Alabama" will display in the autocomplete list.  If the user then presses the tab key or clicks elsewhere to lose focus, the autocomplete combobox will auto-fill with "Alabama".  This way, the user does not have to type in the entire matching text once there is only a single match.

```
<select id="state1">
    <option value=""></option>
    <option value="AL">Alabama</option>
    <option value="AK">Alaska</option>
    <option value="AZ">Arizona</option>
    <option value="AR">Arkansas</option>
</select>
```
