### PR TITLE
Fix unclosed <div> in labeledslider.

### DIFF
--- a/ui/jquery.ui.labeledslider.js
+++ b/ui/jquery.ui.labeledslider.js
@@ -55,7 +55,7 @@
          this.uiSlider =
              this.element
                 .wrap( '<div class="ui-slider-wrapper ui-widget"></div>' )
-                .before( '<div class="ui-slider-labels">' )
+                .before( '<div class="ui-slider-labels"></div>' )
                 .parent()
                 .addClass( this.orientation )
                 .css( 'font-size', this.element.css('font-size') );


### PR DESCRIPTION
Hi @bseth99,

I am not 100% sure if this is the "intended" fix. But this resolves my problem of the resulting XHTML page not showing the labeled sliders in Chrome.

best regards
