### PR TITLE
combobox - enable custom 'position' option

### DIFF
--- a/ui/jquery.ui.combobox.js
+++ b/ui/jquery.ui.combobox.js
@@ -47,7 +47,7 @@
 
          var self = this,
              select = this.element.hide(),
-             input, wrapper;
+             input, wrapper, position;
 
          input = this.uiInput =
                   $( "<input />" )
@@ -63,11 +63,17 @@
                .addClass( 'ui-combobox' )
                .insertAfter( select );
 
+         // pass in default jquery.ui.autocomplete position if none is specified
+         position = this.options.hasOwnProperty('position') ?
+                      this.options.position :
+                      { my: "left top", at: "left bottom", collision: "none" };
+
          input
           .autocomplete({
 
              delay: 0,
              minLength: 0,
+             position: position,
 
              appendTo: wrapper,
              source: $.proxy( this, "_linkSelectList" ),


### PR DESCRIPTION
jquery.ui.autocomplete allows customization of the positioning of the suggestions menu (see http://api.jqueryui.com/autocomplete/#option-position ), but there's no way to pass this parameter though combobox.
This commit enables this by letting you pass a 'position' parameter in the options passed to the .combobox() call. If you do not specify a position parameter, the default value used by jquery.ui.autocomplete is passed in instead.
